### PR TITLE
Add support for cross-account cognito ARNs

### DIFF
--- a/app/services/cognito/cognito_base_service.rb
+++ b/app/services/cognito/cognito_base_service.rb
@@ -29,7 +29,12 @@ module Cognito
 
     # The user pool ID for the user pool where we want to update user attributes
     def user_pool_id
-      ENV['AWS_COGNITO_USER_POOL_ID']
+      if ENV['AWS_COGNITO_USER_POOL_ID'].start_with?('arn:') 
+        # This assumes a fixed cognito pool ID length of 19 chars
+        test = ENV['AWS_COGNITO_USER_POOL_ID'].reverse[0...19].reverse
+      else
+        ENV['AWS_COGNITO_USER_POOL_ID']
+      end
     end
   end
 end


### PR DESCRIPTION
From testing the AWS account re-structure, the cognito admin functions on the AWS Ruby SDK raise an exception if the Cognito pool ID exceeds 55 chars.

In **all** calls to cognito admin functions (across services), we need to strip out the preceding ARN qualifier and just use the pool ID (which in this instance is the last 19 characters of the string) in cross-account lookup scenarios (e.g. AWS re-structure deployments). This is due to the admin functions placing a validation cap at 55 chars on the pool ID (see below docs), despite a fully qualified ARN working for normal login, password reset etc.:

https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminGetUser.html#API_AdminGetUser_RequestSyntax

A more robust approach, however, would be to sub-string from the end of the string until a forward slash is found. There are challenges, however, insofar that splicing (ruby function) the string can result in an out of bounds exception (hence this possible approach).

I've tested locally that this resolves the issue seen in the new dev environment (logs below for reference), where admin functions (as a product or rate limiting are used):

[INFO  2020-06-08 18:31:06]  [4a5f30ff-fd44-4d3e-acb4-d0aac70a88d5] [Aws::CognitoIdentityProvider::Client 400 0.046094 0 retries] admin_list_groups_for_user(user_pool_id:"arn:aws:cognito-idp:eu-west-2:018330602464:userpool/eu-west-XXXXX",username:"[FILTERED]") Aws::CognitoIdentityProvider::Errors::InvalidParameterException 2 validation errors detected: Value 'arn:aws:cognito-idp:eu-west-2:018330602464:userpool/eu-west-XXXXXXXXXX' at 'userPoolId' failed to satisfy constraint: Member must have length less than or equal to 55; Value 'arn:aws:cognito-idp:eu-west-2:XXXXX:userpool/eu-west-XXXXX' at 'userPoolId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w-]+_[0-9a-zA-Z]+

Note - I've run unit tests locally and these passed but looking at the drone pipeline, these fail due to a null reference being encountered (I'm assuming this is due to env settings in unit test context). Rather than lodging a full PR with all parts of the fix, this is intended to demonstrate the code/infrastructure adjustments we need to make (hence the PR being draft) for others to avail of.