### PR TITLE
[CAZB-2783] Add account lockout mechanism

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,11 @@ GTM_URL_OVERRIDES=
 
 # Configurable CSV upload size limit
 CSV_FILE_SIZE_LIMIT_MB=
+
+
+# Time for which the user is going to be locked out after exceeding maximum number of failed logins.
+# Expressed in minutes.
+LOCKOUT_TIMEOUT=
+
+# Maximum amount of attempts after which user will be locked out.
+LOCKOUT_LOGIN_ATTEMPTS=

--- a/.env.example
+++ b/.env.example
@@ -32,11 +32,3 @@ GTM_URL_OVERRIDES=
 
 # Configurable CSV upload size limit
 CSV_FILE_SIZE_LIMIT_MB=
-
-
-# Time for which the user is going to be locked out after exceeding maximum number of failed logins.
-# Expressed in minutes.
-LOCKOUT_TIMEOUT=
-
-# Maximum amount of attempts after which user will be locked out.
-LOCKOUT_LOGIN_ATTEMPTS=

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
   NewCops: enable
 
 Layout/LineLength:
-  Max: 99
+  Max: 110
   IgnoredPatterns: ['(\A|\s)#']
 
 Metrics/BlockLength:

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'activerecord-nulldb-adapter'
 gem 'aws-sdk-cognitoidentityprovider'
 gem 'aws-sdk-rails'
 gem 'aws-sdk-s3'
+gem 'aws-sdk-secretsmanager'
 gem 'bootsnap', require: false
 gem 'devise'
 gem 'haml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.104.3)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
+    aws-sdk-secretsmanager (1.41.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-ses (1.33.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
@@ -399,6 +402,7 @@ DEPENDENCIES
   aws-sdk-cognitoidentityprovider
   aws-sdk-rails
   aws-sdk-s3
+  aws-sdk-secretsmanager
   better_errors
   binding_of_caller
   bootsnap

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -3,7 +3,7 @@
 ##
 # Controller class for the password change.
 #
-class PasswordsController < ApplicationController
+class PasswordsController < ApplicationController # rubocop:disable Metrics/ClassLength
   # checks if a user is logged in
   before_action :authenticate_user!, only: %i[new create]
   # checks if a user has a 'FORCE_NEW_PASSWORD' status
@@ -119,6 +119,7 @@ class PasswordsController < ApplicationController
   def change
     update_password_call
     Cognito::ForgotPassword::UpdateUser.call(reset_counter: 1, username: username)
+    reset_user_lockout_data
     redirect_to success_passwords_path
   rescue Cognito::CallException => e
     redirect_to confirm_reset_passwords_path, alert: e.message
@@ -206,5 +207,10 @@ class PasswordsController < ApplicationController
   # username in session
   def username_in_session
     session[:password_reset_username]
+  end
+
+  # Updates user data associated with account lockout.
+  def reset_user_lockout_data
+    Cognito::Lockout::UpdateUser.call(username: username, failed_logins: 0)
   end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -3,7 +3,7 @@
 ##
 # Controller class for the password change.
 #
-class PasswordsController < ApplicationController # rubocop:disable Metrics/ClassLength
+class PasswordsController < ApplicationController
   # checks if a user is logged in
   before_action :authenticate_user!, only: %i[new create]
   # checks if a user has a 'FORCE_NEW_PASSWORD' status

--- a/app/services/cognito/auth_user.rb
+++ b/app/services/cognito/auth_user.rb
@@ -50,6 +50,7 @@ module Cognito
     rescue AWS_ERROR::NotAuthorizedException => e
       log_error e
       Cognito::Lockout::VerifyInvalidLogins.call(username: username)
+      false
     rescue AWS_ERROR::ServiceError => e
       log_error e
       false

--- a/app/services/cognito/auth_user.rb
+++ b/app/services/cognito/auth_user.rb
@@ -63,7 +63,7 @@ module Cognito
     # Performs the call to Cognito. Returns Cognito response.
     def auth_user
       log_action 'Authenticating user'
-      auth_response = COGNITO_CLIENT.initiate_auth(
+      auth_response = client.initiate_auth(
         client_id: ENV['AWS_COGNITO_CLIENT_ID'],
         auth_flow: 'USER_PASSWORD_AUTH',
         auth_parameters: { 'USERNAME' => username, 'PASSWORD' => password }

--- a/app/services/cognito/client.rb
+++ b/app/services/cognito/client.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Singleton Class used to request Cognito client.
+  class Client
+    include Singleton
+
+    attr_reader :client
+
+    ##
+    # Initializer method for the service.
+    #
+    def initialize
+      @client = load_client
+    end
+
+    ##
+    # Method called when class does not implement the method
+    # Then we try to call Cognito Client if respond to that method
+    def method_missing(method, *args, &block)
+      return client.send(method, *args, &block) if respond_to_missing?(method)
+
+      super
+    rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException,
+           Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException => e
+      Rails.logger.info "Rescue From: #{e.class.name} - rotate credentials"
+      # reload Cognito Client
+      @client = load_client
+      # retry
+      client.send(method, *args, &block)
+    end
+
+    ##
+    # Method which check if Cognito Client respond to the missing method.
+    def respond_to_missing?(method, include_private = false) # rubocop:disable Style/OptionalBooleanParameter
+      client.respond_to?(method) || super
+    end
+
+    private
+
+    # Loads AWS Cognito Client
+    def load_client
+      return Aws::CognitoIdentityProvider::Client.new unless cognito_sdk_secret
+
+      Aws::CognitoIdentityProvider::Client.new(credentials: secret_manager_credentials)
+    end
+
+    # Check if COGNITO_SDK_SECRET is set
+    def cognito_sdk_secret
+      ENV['COGNITO_SDK_SECRET']
+    end
+
+    # Loads Credentials from SecretManager
+    def secret_manager_credentials
+      sm_credentials = JSON.parse(
+        secret_manager_client.get_secret_value(secret_id: cognito_sdk_secret).secret_string
+      )
+      Aws::Credentials.new(
+        sm_credentials['awsAccessKeyId'],
+        sm_credentials['awsSecretAccessKey']
+      )
+    end
+
+    # Loads SecretManager Client.
+    def secret_manager_client
+      Aws::SecretsManager::Client.new(
+        region: ENV['AWS_REGION'],
+        credentials: Aws::ECSCredentials.new({ ip_address: '169.254.170.2' })
+      )
+    end
+  end
+end

--- a/app/services/cognito/cognito_base_service.rb
+++ b/app/services/cognito/cognito_base_service.rb
@@ -7,6 +7,12 @@ module Cognito
   class CognitoBaseService < BaseService
     # Symbolizes base class for all Aws::CognitoIdentityProvider errors.
     AWS_ERROR = Aws::CognitoIdentityProvider::Errors
+    # Names of the custom Cognito attributes
+    FAILED_LOGINS_ATTR = 'custom:failed-logins'
+    LOCKOUT_TIME_ATTR = 'custom:lockout-time'
+    # Env variables associated with the lockout mechanism
+    LOCKOUT_LOGIN_ATTEMPTS = ENV.fetch('LOCKOUT_LOGIN_ATTEMPTS', 5).to_i
+    LOCKOUT_TIMEOUT = ENV.fetch('LOCKOUT_TIMEOUT', 30).to_i
 
     # Logs success message on +info+ level
     def log_successful_call

--- a/app/services/cognito/cognito_base_service.rb
+++ b/app/services/cognito/cognito_base_service.rb
@@ -37,5 +37,12 @@ module Cognito
     def user_pool_id
       ENV['AWS_COGNITO_USER_POOL_ID'].split('/').last
     end
+
+    private
+
+    # Returns Cognito::Client instance
+    def client
+      Cognito::Client.instance
+    end
   end
 end

--- a/app/services/cognito/forgot_password/confirm.rb
+++ b/app/services/cognito/forgot_password/confirm.rb
@@ -88,7 +88,7 @@ module Cognito
       # Perform call to AWS Cognito to set a new password.
       def confirm_forgot_password
         log_action 'Confirming forgot password'
-        COGNITO_CLIENT.confirm_forgot_password(
+        client.confirm_forgot_password(
           client_id: ENV['AWS_COGNITO_CLIENT_ID'],
           username: username,
           password: password,

--- a/app/services/cognito/forgot_password/get_user.rb
+++ b/app/services/cognito/forgot_password/get_user.rb
@@ -32,7 +32,7 @@ module Cognito
 
       # Perform the call to Cognito service to get user attributes
       def admin_get_user
-        COGNITO_CLIENT.admin_get_user({ user_pool_id: user_pool_id, username: username })
+        client.admin_get_user({ user_pool_id: user_pool_id, username: username })
       rescue AWS_ERROR::ServiceError
         raise Cognito::CallException.new('', forgot_password_error_path)
       end

--- a/app/services/cognito/forgot_password/reset.rb
+++ b/app/services/cognito/forgot_password/reset.rb
@@ -59,7 +59,7 @@ module Cognito
       # Requests a Cognito service to perform email send with a new temporary password.
       def cognito_call
         log_action 'Forgot password call and email sending'
-        COGNITO_CLIENT.forgot_password(
+        client.forgot_password(
           client_id: ENV['AWS_COGNITO_CLIENT_ID'],
           username: username
         )

--- a/app/services/cognito/forgot_password/update_user.rb
+++ b/app/services/cognito/forgot_password/update_user.rb
@@ -38,7 +38,7 @@ module Cognito
       # Perform the call to Cognito service to update user attributes
       def admin_update_user
         log_action "Updating the password reset rate limit fields to: #{reset_counter}"
-        COGNITO_CLIENT.admin_update_user_attributes(
+        client.admin_update_user_attributes(
           { user_pool_id: user_pool_id, username: username, user_attributes: user_attributes }
         )
         log_successful_call

--- a/app/services/cognito/get_user.rb
+++ b/app/services/cognito/get_user.rb
@@ -50,7 +50,7 @@ module Cognito
     def user_data
       unless defined? @user_data
         log_action 'Getting user'
-        @user_data = COGNITO_CLIENT.get_user(access_token: access_token)
+        @user_data = client.get_user(access_token: access_token)
         log_successful_call
       end
 

--- a/app/services/cognito/lockout/attempt_user_unlock.rb
+++ b/app/services/cognito/lockout/attempt_user_unlock.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Module used to manage the account lockout
+  module Lockout
+    ##
+    # Class responsible for unlocking user when user can be unlocked
+    class AttemptUserUnlock < CognitoBaseService
+      ##
+      # Initializer method for the service.
+      #
+      # ==== Attributes
+      # * +username+ - string, user email address
+      def initialize(username:)
+        @username = username
+      end
+
+      ##
+      # Unlocks user when it's possible
+      def call
+        unlock_user if user_data.unlockable?
+      end
+
+      private
+
+      attr_reader :username
+
+      # Method unlocks the user but starts counting invalid login attempts.
+      def unlock_user
+        update_user(failed_logins: 0)
+      end
+
+      # Method calls service which returns user data.
+      def user_data
+        @user_data ||= Cognito::Lockout::UserData.new(username: username)
+      end
+
+      # Method calls service responsible for user updates.
+      def update_user(failed_logins:, lockout_time: nil)
+        Cognito::Lockout::UpdateUser.call(
+          username: username,
+          failed_logins: failed_logins,
+          lockout_time: lockout_time
+        )
+      end
+    end
+  end
+end

--- a/app/services/cognito/lockout/is_user_locked.rb
+++ b/app/services/cognito/lockout/is_user_locked.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Module used to manage the account lockout
+  module Lockout
+    ##
+    # Class responsible for checking whether provided user is locked.
+    #
+    class IsUserLocked < CognitoBaseService
+      ##
+      # Initializer method for the service.
+      #
+      # ==== Attributes
+      # * +username+ - string, user email address
+      def initialize(username:)
+        @username = username
+      end
+
+      ##
+      # Checks if user is locked. Removes lockout when it's possible.
+      # Returns boolean.
+      def call
+        user_data.locked?
+      end
+
+      private
+
+      attr_reader :username
+
+      # Method calls service which returns user data.
+      def user_data
+        @user_data ||= Cognito::Lockout::UserData.new(username: username)
+      end
+    end
+  end
+end

--- a/app/services/cognito/lockout/update_user.rb
+++ b/app/services/cognito/lockout/update_user.rb
@@ -38,7 +38,7 @@ module Cognito
       # Perform the call to Cognito service to update user attributes
       def admin_update_user
         log_action 'Updating user attributes associated with account lockout'
-        COGNITO_CLIENT.admin_update_user_attributes(
+        client.admin_update_user_attributes(
           { user_pool_id: user_pool_id, username: username, user_attributes: user_attributes }
         )
         log_successful_call

--- a/app/services/cognito/lockout/update_user.rb
+++ b/app/services/cognito/lockout/update_user.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Module used to manage the account lockout
+  module Lockout
+    ##
+    # Class responsible for requesting a Cognito service to update account lockout attributes
+    #
+    class UpdateUser < CognitoBaseService
+      ##
+      # Initializer method for the service.
+      #
+      # ==== Attributes
+      # * +username+ - string, user email address
+      # * +failed_logins+ - integer, failed logins counter
+      # * +lockout_time+ - integer, current datetime converted to integer
+      def initialize(username:, failed_logins:, lockout_time: nil)
+        @username = username
+        @failed_logins = failed_logins
+        @lockout_time = lockout_time
+      end
+
+      ##
+      # Perform the call to AWS Cognito and returns true if errors were not raised
+      def call
+        admin_update_user
+        true
+      end
+
+      private
+
+      # Variables used internally by the service
+      attr_reader :username, :failed_logins, :lockout_time
+
+      # Perform the call to Cognito service to update user attributes
+      def admin_update_user
+        log_action 'Updating user attributes associated with account lockout'
+        COGNITO_CLIENT.admin_update_user_attributes(
+          { user_pool_id: user_pool_id, username: username, user_attributes: user_attributes }
+        )
+        log_successful_call
+      rescue AWS_ERROR::ServiceError => e
+        log_error e
+        raise CallException, 'Something went wrong'
+      end
+
+      # An array of name-value pairs representing user attributes we want to update
+      def user_attributes
+        [
+          {
+            name: FAILED_LOGINS_ATTR,
+            value: failed_logins.to_s
+          },
+          {
+            name: LOCKOUT_TIME_ATTR,
+            value: lockout_time.to_s
+          }
+        ]
+      end
+    end
+  end
+end

--- a/app/services/cognito/lockout/user_data.rb
+++ b/app/services/cognito/lockout/user_data.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Module used to manage the password change
+  module Lockout
+    ##
+    # Class responsible for requesting a Cognito service to get rate limiting fields
+    #
+    class UserData < CognitoBaseService
+      ##
+      # Initializer method for the service.
+      #
+      # ==== Attributes
+      # * +username+ - string, user email address
+      def initialize(username:)
+        @username = username
+      end
+
+      # Quantity of invalid login attempts.
+      # Returns integer.
+      def invalid_logins
+        (extract_attr(FAILED_LOGINS_ATTR) || 0).to_i
+      end
+
+      # Time when user was locked out.
+      # Returns ActiveSupport::TimeWithZone object when the value is set.
+      # Returns nil otherwise.
+      def lockout_time
+        date_string = extract_attr(LOCKOUT_TIME_ATTR)
+        date_string.blank? ? nil : Time.zone.parse(date_string)
+      end
+
+      # Returns information if user can be unlocked.
+      # User can be unlocked only when he is already locked and his lockout time was longer
+      def unlockable?
+        lockout_time ? lockout_time_exceeded? : false
+      end
+
+      # Information if user is blocked.
+      # Returns boolean.
+      def locked?
+        !lockout_time.nil?
+      end
+
+      private
+
+      # Variable used internally by the service
+      attr_reader :username
+
+      # Perform the call to Cognito service to get user attributes
+      def user_data
+        @user_data ||= COGNITO_CLIENT.admin_get_user(
+          {
+            user_pool_id: user_pool_id,
+            username: username
+          }
+        )
+      end
+
+      # Extracts provided parameter from the Cognito response
+      def extract_attr(name)
+        user_data.user_attributes.find { |attr| attr.name == name }&.value
+      end
+
+      # Verifies if set lockout time exceeded lockout timeout.
+      # Returns boolean.
+      def lockout_time_exceeded?
+        lockout_time < LOCKOUT_TIMEOUT.minutes.ago
+      end
+    end
+  end
+end

--- a/app/services/cognito/lockout/user_data.rb
+++ b/app/services/cognito/lockout/user_data.rb
@@ -52,7 +52,7 @@ module Cognito
 
       # Perform the call to Cognito service to get user attributes
       def user_data
-        @user_data ||= COGNITO_CLIENT.admin_get_user(
+        @user_data ||= client.admin_get_user(
           {
             user_pool_id: user_pool_id,
             username: username

--- a/app/services/cognito/lockout/verify_invalid_logins.rb
+++ b/app/services/cognito/lockout/verify_invalid_logins.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Module used to manage the account lockout
+  module Lockout
+    ##
+    # Class responsible for reacting to situation when user provided a valid username but invalid password.
+    #
+    class VerifyInvalidLogins < CognitoBaseService
+      ##
+      # Initializer method for the service.
+      #
+      # ==== Attributes
+      # * +username+ - string, user email address
+      def initialize(username:)
+        @username = username
+      end
+
+      ##
+      # Updates user cognito attributes based on their current value.
+      def call
+        increment_failed_logins unless invalid_logins_exceeded?
+        lock_user if invalid_logins_exceeded? && !user_data.locked?
+        unlock_user if invalid_logins_exceeded? && user_data.unlockable?
+      end
+
+      private
+
+      attr_reader :username
+
+      # Method checks if user exceeded maximum invalid login attempts.
+      # Returns boolean.
+      def invalid_logins_exceeded?
+        user_data.invalid_logins >= LOCKOUT_LOGIN_ATTEMPTS
+      end
+
+      # Method calls update service with the incremented invalid login count.
+      def increment_failed_logins
+        update_user(failed_logins: user_data.invalid_logins + 1)
+      end
+
+      # Method class update service with data locking out the user.
+      def lock_user
+        update_user(
+          failed_logins: user_data.invalid_logins,
+          lockout_time: Time.zone.now.iso8601
+        )
+      end
+
+      # Method unlocks the user but starts counting invalid login attempts.
+      def unlock_user
+        update_user(failed_logins: 1)
+      end
+
+      # Method calls service which returns user data.
+      def user_data
+        @user_data ||= Cognito::Lockout::UserData.new(username: username)
+      end
+
+      # Method calls service responsible for user updates.
+      def update_user(failed_logins:, lockout_time: nil)
+        Cognito::Lockout::UpdateUser.call(
+          username: username,
+          failed_logins: failed_logins,
+          lockout_time: lockout_time
+        )
+      end
+    end
+  end
+end

--- a/app/services/cognito/lockout/verify_invalid_logins.rb
+++ b/app/services/cognito/lockout/verify_invalid_logins.rb
@@ -34,7 +34,7 @@ module Cognito
       # Method checks if user exceeded maximum invalid login attempts.
       # Returns boolean.
       def invalid_logins_exceeded?
-        user_data.invalid_logins >= LOCKOUT_LOGIN_ATTEMPTS
+        user_data(reload: true).invalid_logins >= LOCKOUT_LOGIN_ATTEMPTS
       end
 
       # Method calls update service with the incremented invalid login count.
@@ -55,9 +55,14 @@ module Cognito
         update_user(failed_logins: 1)
       end
 
+      # Method returns either already stored user data or fetches them from Cognito.
+      def user_data(reload: false)
+        reload ? (@user_data = user_data_call) : (@user_data ||= user_data_call)
+      end
+
       # Method calls service which returns user data.
-      def user_data
-        @user_data ||= Cognito::Lockout::UserData.new(username: username)
+      def user_data_call
+        Cognito::Lockout::UserData.new(username: username)
       end
 
       # Method calls service responsible for user updates.

--- a/app/services/cognito/respond_to_auth_challenge.rb
+++ b/app/services/cognito/respond_to_auth_challenge.rb
@@ -74,7 +74,7 @@ module Cognito
     # Sets a new user password on Cognito.
     def call_cognito
       log_action 'Respond to auth call'
-      result = COGNITO_CLIENT.respond_to_auth_challenge(
+      result = client.respond_to_auth_challenge(
         challenge_name: 'NEW_PASSWORD_REQUIRED',
         client_id: ENV['AWS_COGNITO_CLIENT_ID'],
         session: user.aws_session,

--- a/config/initializers/cognito_client.rb
+++ b/config/initializers/cognito_client.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-COGNITO_CLIENT = Aws::CognitoIdentityProvider::Client.new

--- a/features/account_lockout.feature
+++ b/features/account_lockout.feature
@@ -1,0 +1,9 @@
+Feature: Lockout user account after limited amount of login attempts
+  As a Licensing Authority
+  I want to be uncapable of signing in after limited amount of login attempts
+  So I am sure that my password won't be brutforced
+
+  Scenario: Login with locked account
+    Given I am on the Sign in page
+      And I sign in on the locked out account
+    Then I should see 'Enter a valid email address and password'

--- a/features/step_definitions/account_lockout_steps.rb
+++ b/features/step_definitions/account_lockout_steps.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+When('I sign in on the locked out account') do
+  allow(Cognito::Lockout::IsUserLocked).to receive(:call).and_return(true)
+  visit new_user_session_path
+  basic_sign_in
+  end

--- a/features/step_definitions/account_lockout_steps.rb
+++ b/features/step_definitions/account_lockout_steps.rb
@@ -4,4 +4,4 @@ When('I sign in on the locked out account') do
   allow(Cognito::Lockout::IsUserLocked).to receive(:call).and_return(true)
   visit new_user_session_path
   basic_sign_in
-  end
+end

--- a/spec/requests/passwords/change_spec.rb
+++ b/spec/requests/passwords/change_spec.rb
@@ -35,6 +35,9 @@ describe 'PasswordsController - POST #change', type: :request do
       allow(Cognito::ForgotPassword::UpdateUser)
         .to receive(:call).with(reset_counter: 1, username: username)
                           .and_return(true)
+      allow(Cognito::Lockout::UpdateUser)
+        .to receive(:call).with(username: username, failed_logins: 0)
+                          .and_return(true)
     end
 
     it 'returns redirect to success page' do
@@ -52,6 +55,12 @@ describe 'PasswordsController - POST #change', type: :request do
       expect(session[:password_reset_username]).to be_nil
     end
 
+    it 'updates user lockout data' do
+      http_request
+      expect(Cognito::Lockout::UpdateUser).to have_received(:call)
+        .with(username: username, failed_logins: 0)
+    end
+
     context 'when service raises exception' do
       before do
         allow(Cognito::ForgotPassword::Confirm)
@@ -62,6 +71,11 @@ describe 'PasswordsController - POST #change', type: :request do
       it 'returns redirect to confirm_reset_passwords_path' do
         subject
         expect(response).to redirect_to(confirm_reset_passwords_path)
+      end
+
+      it 'does not update user lockout data' do
+        http_request
+        expect(Cognito::Lockout::UpdateUser).not_to have_received(:call)
       end
     end
 
@@ -75,6 +89,11 @@ describe 'PasswordsController - POST #change', type: :request do
       it 'returns redirect to confirm_reset_passwords_path' do
         subject
         expect(response).to redirect_to(confirm_reset_passwords_path)
+      end
+
+      it 'does not update user lockout data' do
+        http_request
+        expect(Cognito::Lockout::UpdateUser).not_to have_received(:call)
       end
     end
   end

--- a/spec/requests/passwords/change_spec.rb
+++ b/spec/requests/passwords/change_spec.rb
@@ -56,7 +56,7 @@ describe 'PasswordsController - POST #change', type: :request do
     end
 
     it 'updates user lockout data' do
-      http_request
+      subject
       expect(Cognito::Lockout::UpdateUser).to have_received(:call)
         .with(username: username, failed_logins: 0)
     end
@@ -74,7 +74,7 @@ describe 'PasswordsController - POST #change', type: :request do
       end
 
       it 'does not update user lockout data' do
-        http_request
+        subject
         expect(Cognito::Lockout::UpdateUser).not_to have_received(:call)
       end
     end
@@ -92,7 +92,7 @@ describe 'PasswordsController - POST #change', type: :request do
       end
 
       it 'does not update user lockout data' do
-        http_request
+        subject
         expect(Cognito::Lockout::UpdateUser).not_to have_received(:call)
       end
     end

--- a/spec/requests/passwords/send_confirmation_code_spec.rb
+++ b/spec/requests/passwords/send_confirmation_code_spec.rb
@@ -45,7 +45,7 @@ describe 'PasswordsController - POST #send_confirmation_code', type: :request do
 
     context 'when service raises `UserNotFoundException` exception' do
       before do
-        allow(COGNITO_CLIENT).to receive(:forgot_password).and_raise(
+        allow(Cognito::Client.instance).to receive(:forgot_password).and_raise(
           Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', '')
         )
         subject

--- a/spec/services/cognito/auth_user_spec.rb
+++ b/spec/services/cognito/auth_user_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Cognito::AuthUser do
 
   context 'with successful call' do
     before do
-      allow(COGNITO_CLIENT).to receive(:initiate_auth).with(
+      allow(Cognito::Client.instance).to receive(:initiate_auth).with(
         client_id: anything,
         auth_flow: 'USER_PASSWORD_AUTH',
         auth_parameters: { 'USERNAME' => username, 'PASSWORD' => password }
@@ -82,7 +82,7 @@ RSpec.describe Cognito::AuthUser do
 
   context 'when call raises exception' do
     before do
-      allow(COGNITO_CLIENT)
+      allow(Cognito::Client.instance)
         .to receive(:initiate_auth)
         .and_raise(
           Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new('', 'error')

--- a/spec/services/cognito/client_spec.rb
+++ b/spec/services/cognito/client_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cognito::Client do
+  subject(:service) do
+    Class.new described_class
+  end
+
+  let(:aws_cognito_client) { Aws::CognitoIdentityProvider::Client.new }
+
+  before do
+    allow(Aws::CognitoIdentityProvider::Client).to(
+      receive(:new).and_return(aws_cognito_client)
+    )
+  end
+
+  context 'When cognito client raise ResourceNotFoundException' do
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_raise(
+        Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException.new('', 'error')
+      )
+    end
+
+    it 'retries to call after credentials rotation' do
+      expect(aws_cognito_client).to receive(:list_users).twice
+      begin
+        service.instance.list_users
+      rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException
+        Rails.logger.info 'Servive raises exception'
+      end
+    end
+  end
+
+  context 'When cognito client raise UnrecognizedClientException' do
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_raise(
+        Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException.new('', 'error')
+      )
+    end
+
+    it 'retries to call after credentials rotation' do
+      expect(aws_cognito_client).to receive(:list_users).twice
+      begin
+        service.instance.list_users
+      rescue Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException
+        Rails.logger.info 'Servive raises exception'
+      end
+    end
+  end
+
+  context 'When cognito client raise other exception' do
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_raise(
+        Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', 'error')
+      )
+    end
+
+    it 'does not retries the call' do
+      expect(aws_cognito_client).to receive(:list_users).once
+      begin
+        service.instance.list_users
+      rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+        Rails.logger.info 'Servive raises exception'
+      end
+    end
+  end
+
+  context 'When cognito client raise other exception' do
+    let(:users) { %w[user1 user2] }
+
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_return(users)
+    end
+
+    it 'returns the result frotm the AWS' do
+      response = service.instance.list_users
+      expect(response).to equal(users)
+    end
+
+    it 'calls AWS only once' do
+      expect(aws_cognito_client).to receive(:list_users).once
+      service.instance.list_users
+    end
+  end
+end

--- a/spec/services/cognito/forgot_password/confirm_spec.rb
+++ b/spec/services/cognito/forgot_password/confirm_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Cognito::ForgotPassword::Confirm do
   let(:form) { OpenStruct.new(valid?: true) }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:confirm_forgot_password).with(
+    allow(Cognito::Client.instance).to receive(:confirm_forgot_password).with(
       client_id: anything,
       username: username,
       password: password,
@@ -41,7 +41,7 @@ RSpec.describe Cognito::ForgotPassword::Confirm do
     end
 
     it 'calls Cognito' do
-      expect(COGNITO_CLIENT).to receive(:confirm_forgot_password)
+      expect(Cognito::Client.instance).to receive(:confirm_forgot_password)
       service_call
     end
   end
@@ -61,7 +61,7 @@ RSpec.describe Cognito::ForgotPassword::Confirm do
     let(:error) { "User with username '#{username}' was not found" }
 
     before do
-      allow(COGNITO_CLIENT).to receive(:confirm_forgot_password).with(
+      allow(Cognito::Client.instance).to receive(:confirm_forgot_password).with(
         client_id: anything,
         username: username,
         password: password,

--- a/spec/services/cognito/forgot_password/get_user_spec.rb
+++ b/spec/services/cognito/forgot_password/get_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
   let(:username) { 'user@example.com' }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+    allow(Cognito::Client.instance).to receive(:admin_get_user).with(
       user_pool_id: anything,
       username: username
     ).and_return(true)
@@ -16,7 +16,7 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
 
   context 'with successful call' do
     it 'calls Cognito with proper params and returns true' do
-      expect(COGNITO_CLIENT).to receive(:admin_get_user).with(
+      expect(Cognito::Client.instance).to receive(:admin_get_user).with(
         user_pool_id: anything,
         username: username
       ).and_return(true)
@@ -24,10 +24,10 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
     end
   end
 
-  context 'when `COGNITO_CLIENT.admin_get_user` call fails with proper params' do
+  context 'when `Cognito::Client.instance.admin_get_user` call fails with proper params' do
     context 'and service raises `ServiceError`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(
@@ -42,7 +42,7 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
 
     context 'and service raises `UserNotFoundException`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(

--- a/spec/services/cognito/forgot_password/rate_limit_verification_spec.rb
+++ b/spec/services/cognito/forgot_password/rate_limit_verification_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cognito::ForgotPassword::RateLimitVerification do
   let(:reset_requested) { nil }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+    allow(Cognito::Client.instance).to receive(:admin_get_user).with(
       user_pool_id: anything,
       username: username
     ).and_return(admin_get_user_response)
@@ -67,10 +67,10 @@ RSpec.describe Cognito::ForgotPassword::RateLimitVerification do
     end
   end
 
-  context 'when `COGNITO_CLIENT.admin_get_user` call fails with proper params' do
+  context 'when `Cognito::Client.instance.admin_get_user` call fails with proper params' do
     context 'and service raises `ServiceError`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(
@@ -85,7 +85,7 @@ RSpec.describe Cognito::ForgotPassword::RateLimitVerification do
 
     context 'and service raises `UserNotFoundException`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(

--- a/spec/services/cognito/forgot_password/reset_spec.rb
+++ b/spec/services/cognito/forgot_password/reset_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
     allow(Cognito::ForgotPassword::RateLimitVerification).to receive(:call).with(
       username: username
     ).and_return(true)
-    allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+    allow(Cognito::Client.instance).to receive(:forgot_password).with(
       client_id: anything,
       username: username
     ).and_return(cognito_response)
@@ -31,7 +31,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
     end
 
     it 'calls Cognito' do
-      expect(COGNITO_CLIENT).to receive(:forgot_password)
+      expect(Cognito::Client.instance).to receive(:forgot_password)
       service_call
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
 
     context 'when service raises `ServiceError` exception' do
       before do
-        allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+        allow(Cognito::Client.instance).to receive(:forgot_password).with(
           client_id: anything,
           username: username
         ).and_raise(
@@ -68,7 +68,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
 
     context 'when service raises `UserNotFoundException` exception' do
       before do
-        allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+        allow(Cognito::Client.instance).to receive(:forgot_password).with(
           client_id: anything,
           username: username
         ).and_raise(
@@ -100,7 +100,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
 
       context 'when service raises `UserNotFoundException` exception' do
         before do
-          allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+          allow(Cognito::Client.instance).to receive(:forgot_password).with(
             client_id: anything,
             username: username
           ).and_raise(

--- a/spec/services/cognito/forgot_password/update_user_spec.rb
+++ b/spec/services/cognito/forgot_password/update_user_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
   end
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+    allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
       user_pool_id: anything,
       username: username,
       user_attributes: user_attributes
@@ -38,7 +38,7 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
 
   context 'with successful call' do
     it 'calls Cognito with proper params and returns true' do
-      expect(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+      expect(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
         user_pool_id: anything,
         username: username,
         user_attributes: user_attributes
@@ -47,10 +47,10 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
     end
   end
 
-  context 'when `COGNITO_CLIENT.admin_update_user_attributes` call fails with proper params' do
+  context 'when `Cognito::Client.instance.admin_update_user_attributes` call fails with proper params' do
     context 'and service raises `ServiceError`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+        allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
           user_pool_id: anything,
           username: username,
           user_attributes: user_attributes
@@ -66,7 +66,7 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
 
     context 'and service raises `UserNotFoundException`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+        allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
           user_pool_id: anything,
           username: username,
           user_attributes: user_attributes

--- a/spec/services/cognito/get_user_spec.rb
+++ b/spec/services/cognito/get_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Cognito::GetUser do
   let(:sub) { SecureRandom.uuid }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:get_user)
+    allow(Cognito::Client.instance).to receive(:get_user)
       .with(access_token: token)
       .and_return(cognito_response)
   end

--- a/spec/services/cognito/lockout/attempt_user_unlock_spec.rb
+++ b/spec/services/cognito/lockout/attempt_user_unlock_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cognito::Lockout::AttemptUserUnlock do
+  subject { described_class.call(username: username) }
+
+  let(:username) { 'user@example.com' }
+  let(:unlockable) { true }
+
+  before do
+    user_data_stub = instance_double('Cognito::Lockout::UserData', unlockable?: unlockable)
+    allow(Cognito::Lockout::UserData).to receive(:new).and_return(user_data_stub)
+    allow(Cognito::Lockout::UpdateUser).to receive(:call)
+      .with(username: username, failed_logins: 0, lockout_time: nil)
+
+    subject
+  end
+
+  context 'when user is unlockable' do
+    it 'unlocks user' do
+      expect(Cognito::Lockout::UpdateUser).to have_received(:call)
+        .with(username: username, failed_logins: 0, lockout_time: nil)
+    end
+  end
+
+  context 'when user is not unlockable' do
+    let(:unlockable) { false }
+
+    it 'does not unlock user' do
+      expect(Cognito::Lockout::UpdateUser).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/services/cognito/lockout/is_user_locked_spec.rb
+++ b/spec/services/cognito/lockout/is_user_locked_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cognito::Lockout::IsUserLocked do
+  subject { described_class.call(username: username) }
+
+  let(:username) { 'user@example.com' }
+  let(:locked) { false }
+  let(:unlockable) { false }
+
+  before do
+    user_data_stub = instance_double(
+      Cognito::Lockout::UserData,
+      locked?: locked,
+      unlockable?: unlockable
+    )
+    allow(Cognito::Lockout::UserData).to receive(:new).and_return(user_data_stub)
+  end
+
+  context 'when user is not locked' do
+    it 'returns false' do
+      expect(subject).to eq(false)
+    end
+  end
+
+  context 'when user is locked' do
+    let(:locked) { true }
+
+    it 'returns true' do
+      expect(subject).to eq(true)
+    end
+  end
+end

--- a/spec/services/cognito/lockout/update_user_spec.rb
+++ b/spec/services/cognito/lockout/update_user_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cognito::Lockout::UpdateUser do
+  subject do
+    described_class.call(
+      username: username,
+      failed_logins: failed_logins,
+      lockout_time: lockout_time
+    )
+  end
+
+  let(:username) { 'user@example.com' }
+  let(:failed_logins) { 3 }
+  let(:lockout_time) { Time.zone.now.iso8601 }
+
+  let(:user_attributes) do
+    [
+      {
+        name: 'custom:failed-logins',
+        value: failed_logins.to_s
+      },
+      {
+        name: 'custom:lockout-time',
+        value: lockout_time.to_s
+      }
+    ]
+  end
+
+  before do
+    allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+      user_pool_id: anything,
+      username: username,
+      user_attributes: user_attributes
+    ).and_return(true)
+  end
+
+  context 'with successful call' do
+    it 'calls Cognito with proper params and returns true' do
+      expect(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+        user_pool_id: anything,
+        username: username,
+        user_attributes: user_attributes
+      ).and_return(true)
+      subject
+    end
+  end
+
+  context 'when `COGNITO_CLIENT.admin_update_user_attributes`
+           call fails with proper params' do
+    context 'and service raises `ServiceError`' do
+      before do
+        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+          user_pool_id: anything,
+          username: username,
+          user_attributes: user_attributes
+        ).and_raise(
+          Aws::CognitoIdentityProvider::Errors::ServiceError.new('', 'error')
+        )
+      end
+
+      it 'raises the `CallException`' do
+        expect { subject }.to raise_exception(Cognito::CallException)
+      end
+    end
+
+    context 'and service raises `UserNotFoundException`' do
+      before do
+        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+          user_pool_id: anything,
+          username: username,
+          user_attributes: user_attributes
+        ).and_raise(
+          Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', '')
+        )
+      end
+
+      it 'raises the `CallException`' do
+        expect { subject }.to raise_exception(Cognito::CallException)
+      end
+    end
+  end
+end

--- a/spec/services/cognito/lockout/update_user_spec.rb
+++ b/spec/services/cognito/lockout/update_user_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Cognito::Lockout::UpdateUser do
   end
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+    allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
       user_pool_id: anything,
       username: username,
       user_attributes: user_attributes
@@ -38,7 +38,7 @@ RSpec.describe Cognito::Lockout::UpdateUser do
 
   context 'with successful call' do
     it 'calls Cognito with proper params and returns true' do
-      expect(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+      expect(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
         user_pool_id: anything,
         username: username,
         user_attributes: user_attributes
@@ -47,11 +47,11 @@ RSpec.describe Cognito::Lockout::UpdateUser do
     end
   end
 
-  context 'when `COGNITO_CLIENT.admin_update_user_attributes`
+  context 'when `Cognito::Client.instance.admin_update_user_attributes`
            call fails with proper params' do
     context 'and service raises `ServiceError`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+        allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
           user_pool_id: anything,
           username: username,
           user_attributes: user_attributes
@@ -67,7 +67,7 @@ RSpec.describe Cognito::Lockout::UpdateUser do
 
     context 'and service raises `UserNotFoundException`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+        allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
           user_pool_id: anything,
           username: username,
           user_attributes: user_attributes

--- a/spec/services/cognito/lockout/user_data_spec.rb
+++ b/spec/services/cognito/lockout/user_data_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Cognito::Lockout::UserData do
   let(:lockout_time) { nil }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+    allow(Cognito::Client.instance).to receive(:admin_get_user).with(
       user_pool_id: anything,
       username: username
     ).and_return(user_response)

--- a/spec/services/cognito/lockout/user_data_spec.rb
+++ b/spec/services/cognito/lockout/user_data_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cognito::Lockout::UserData do
+  subject { described_class.new(username: username) }
+
+  let(:username) { 'user@example.com' }
+  let(:user_response) do
+    OpenStruct.new(
+      user_attributes: [
+        OpenStruct.new(name: 'custom:failed-logins', value: failed_logins),
+        OpenStruct.new(name: 'custom:lockout-time', value: lockout_time)
+      ]
+    )
+  end
+
+  let(:failed_logins) { '0' }
+  let(:lockout_time) { nil }
+
+  before do
+    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+      user_pool_id: anything,
+      username: username
+    ).and_return(user_response)
+  end
+
+  describe '.invalid_logins' do
+    context 'when failed-logins is nil' do
+      let(:failed_logins) { nil }
+
+      it 'returns 0' do
+        expect(subject.invalid_logins).to eq 0
+      end
+    end
+
+    context 'when failed-logins is not nil' do
+      let(:failed_logins) { 3 }
+
+      it 'returns the actual value' do
+        expect(subject.invalid_logins).to eq(failed_logins)
+      end
+    end
+  end
+
+  describe '.lockout_time' do
+    context 'when lockout-time is nil' do
+      let(:lockout_time) { nil }
+
+      it 'returns nil' do
+        expect(subject.lockout_time).to eq(nil)
+      end
+    end
+
+    context 'when lockout-time is not nil' do
+      let(:lockout_time) { 10.minutes.ago.iso8601 }
+
+      it 'returns parsed TimeWithZone object' do
+        expect(subject.lockout_time).to be_a(ActiveSupport::TimeWithZone)
+      end
+    end
+  end
+
+  describe '.unlockable?' do
+    context 'when user is not locked out' do
+      let(:lockout_time) { nil }
+
+      it 'returns false' do
+        expect(subject.unlockable?).to eq(false)
+      end
+    end
+
+    context 'when user is locked out and lockout timeout did not exceed' do
+      let(:lockout_time) { Time.zone.now.iso8601 }
+
+      it 'returns false' do
+        expect(subject.unlockable?).to eq(false)
+      end
+    end
+
+    context 'when user is locked out and lockout timeout exceeded' do
+      let(:lockout_time) { 31.minutes.ago.iso8601 }
+
+      it 'returns true' do
+        expect(subject.unlockable?).to eq(true)
+      end
+    end
+  end
+
+  describe '.locked?' do
+    context 'when lockout-time is nil' do
+      let(:lockout_time) { nil }
+
+      it 'returns false' do
+        expect(subject.locked?).to eq(false)
+      end
+    end
+
+    context 'when lockout-time is not nil' do
+      let(:lockout_time) { 10.minutes.ago.iso8601 }
+
+      it 'returns true' do
+        expect(subject.locked?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/cognito/lockout/verify_invalid_logins_spec.rb
+++ b/spec/services/cognito/lockout/verify_invalid_logins_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Cognito::Lockout::VerifyInvalidLogins do
   let(:lockout_timeout) { ENV.fetch('LOCKOUT_TIMEOUT', 30).to_i }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+    allow(Cognito::Client.instance).to receive(:admin_get_user).with(
       user_pool_id: anything,
       username: username
     ).and_return(user_response)

--- a/spec/services/cognito/lockout/verify_invalid_logins_spec.rb
+++ b/spec/services/cognito/lockout/verify_invalid_logins_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cognito::Lockout::VerifyInvalidLogins do
+  subject { described_class.call(username: username) }
+
+  let(:username) { 'user@example.com' }
+  let(:user_response) do
+    OpenStruct.new(
+      user_attributes: [
+        OpenStruct.new(name: 'custom:failed-logins', value: failed_logins),
+        OpenStruct.new(name: 'custom:lockout-time', value: lockout_time)
+      ]
+    )
+  end
+
+  let(:failed_logins) { '0' }
+  let(:lockout_time) { nil }
+
+  let(:lockout_login_attempts) { ENV.fetch('LOCKOUT_LOGIN_ATTEMPTS', 5).to_i }
+  let(:lockout_timeout) { ENV.fetch('LOCKOUT_TIMEOUT', 30).to_i }
+
+  before do
+    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+      user_pool_id: anything,
+      username: username
+    ).and_return(user_response)
+    allow(Cognito::Lockout::UpdateUser).to receive(:call).with(
+      username: username,
+      failed_logins: anything,
+      lockout_time: anything
+    )
+    subject
+  end
+
+  context 'when user is not locked out and limit is not exceeded' do
+    it 'increments invalid-logins attribute' do
+      expect(Cognito::Lockout::UpdateUser)
+        .to have_received(:call)
+        .with(username: username, failed_logins: 1, lockout_time: nil)
+    end
+  end
+
+  context 'when user is not locked out and limit is exceeded' do
+    let(:failed_logins) { lockout_login_attempts.to_s }
+    let(:lockout_time) { nil }
+
+    it 'sets lockout-time attribute' do
+      expect(Cognito::Lockout::UpdateUser)
+        .to have_received(:call)
+        .with(
+          username: username,
+          failed_logins: lockout_login_attempts,
+          lockout_time: Time.zone.now.iso8601
+        )
+    end
+  end
+
+  context 'when user is locked out and lockout timeout is not exceeded' do
+    let(:failed_logins) { lockout_login_attempts.to_s }
+    let(:lockout_time) { Time.zone.now.iso8601 }
+
+    it 'does not perform any update' do
+      expect(Cognito::Lockout::UpdateUser).not_to have_received(:call)
+    end
+  end
+
+  context 'when user is locked out and lockout timeout exceeded' do
+    let(:failed_logins) { lockout_login_attempts.to_s }
+    let(:lockout_time) { (lockout_timeout + 10).minutes.ago.iso8601 }
+
+    it 'sets invalid-logins to 1 and lockout-time to nil' do
+      expect(Cognito::Lockout::UpdateUser)
+        .to have_received(:call)
+        .with(username: username, failed_logins: 1, lockout_time: nil)
+    end
+  end
+end

--- a/spec/services/cognito/respond_to_auth_spec.rb
+++ b/spec/services/cognito/respond_to_auth_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Cognito::RespondToAuthChallenge do
     allow(Cognito::GetUser).to receive(:call)
       .with(access_token: token, user: user, username: user.username)
       .and_return(cognito_user)
-    allow(COGNITO_CLIENT).to receive(:respond_to_auth_challenge)
+    allow(Cognito::Client.instance).to receive(:respond_to_auth_challenge)
       .with(
         challenge_name: 'NEW_PASSWORD_REQUIRED',
         client_id: anything,
@@ -64,7 +64,7 @@ RSpec.describe Cognito::RespondToAuthChallenge do
     let(:error) { I18n.t('password.errors.complexity') }
 
     before do
-      allow(COGNITO_CLIENT).to receive(:respond_to_auth_challenge).and_raise(
+      allow(Cognito::Client.instance).to receive(:respond_to_auth_challenge).and_raise(
         Aws::CognitoIdentityProvider::Errors::InvalidPasswordException.new('', '')
       )
     end
@@ -78,7 +78,7 @@ RSpec.describe Cognito::RespondToAuthChallenge do
     let(:error) { I18n.t('expired_session') }
 
     before do
-      allow(COGNITO_CLIENT).to receive(:respond_to_auth_challenge).and_raise(
+      allow(Cognito::Client.instance).to receive(:respond_to_auth_challenge).and_raise(
         Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', '')
       )
     end


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZB-2783

## Description
Added account lockout mechanism same as [here](https://github.com/InformedSolutions/JAQU-CAZ-MOD-UI/pull/205)
Additionaly support for using Secret Manager in Cognito client added - to align with other services

## How Has This Been Tested?
Existing test case are modified, new added

## Screenshots (if appropriate):
N/A
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes a link to an issue (if apply)
- [x] I have added tests to cover my changes.
