### PR TITLE
[CAZB-2783] Reset counter on successful login

### DIFF
--- a/app/services/cognito/auth_user.rb
+++ b/app/services/cognito/auth_user.rb
@@ -69,6 +69,7 @@ module Cognito
         auth_flow: 'USER_PASSWORD_AUTH',
         auth_parameters: { 'USERNAME' => username, 'PASSWORD' => password }
       )
+      Cognito::Lockout::UpdateUser.call(username: username, failed_logins: 0)
       log_successful_call
       auth_response
     end

--- a/spec/services/cognito/client_spec.rb
+++ b/spec/services/cognito/client_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Cognito::Client do
       expect(aws_cognito_client).to receive(:list_users).twice
       begin
         service.instance.list_users
-      rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException
-        Rails.logger.info 'Servive raises exception'
+      rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException # rubocop:disable Lint/SuppressedException
       end
     end
   end
@@ -43,8 +42,7 @@ RSpec.describe Cognito::Client do
       expect(aws_cognito_client).to receive(:list_users).twice
       begin
         service.instance.list_users
-      rescue Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException
-        Rails.logger.info 'Servive raises exception'
+      rescue Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException # rubocop:disable Lint/SuppressedException
       end
     end
   end
@@ -60,8 +58,7 @@ RSpec.describe Cognito::Client do
       expect(aws_cognito_client).to receive(:list_users).once
       begin
         service.instance.list_users
-      rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
-        Rails.logger.info 'Servive raises exception'
+      rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException # rubocop:disable Lint/SuppressedException
       end
     end
   end


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZB-2783?focusedCommentId=236364

## Description
When a user enters correct password against the account the incorrect-password-attempts should be reset to 0 and the lockout-time to nil.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes a link to an issue (if apply)
- [ ] I have added tests to cover my changes.
