### PR TITLE
[CAZB-3419] Use preferred_username as user id

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User
 
   # Attribute that is being used to authorize a user and use it in csv uploading.
   attr_accessor :email, :username, :aws_status, :aws_session, :sub,
-                :confirmation_code, :hashed_password, :login_ip
+                :confirmation_code, :hashed_password, :login_ip, :preferred_username
 
   # Overrides default initializer for compliance with Devise Gem.
   def initialize(options = {})
@@ -45,6 +45,7 @@ class User
       aws_status: aws_status,
       aws_session: aws_session,
       sub: sub,
+      preferred_username: preferred_username,
       hashed_password: hashed_password,
       login_ip: login_ip
     }

--- a/app/services/cognito/get_user.rb
+++ b/app/services/cognito/get_user.rb
@@ -25,6 +25,7 @@ module Cognito
     # Sets the details of current user using Cognito response.
     def call
       update_user
+      update_preferred_username
       user
     end
 
@@ -36,6 +37,7 @@ module Cognito
       user.email = extract_attr('email')
       user.sub = extract_attr('sub')
       user.aws_status = 'OK'
+      user.preferred_username = preferred_username || sub
     end
 
     # Returns a string, eg. `test@example.com`
@@ -54,6 +56,25 @@ module Cognito
       end
 
       @user_data
+    end
+
+    # Requesting a Cognito service to update `preferred_username` attribute
+    def update_preferred_username
+      Cognito::UpdatePreferredUsername.call(
+        username: username,
+        preferred_username: preferred_username,
+        sub: sub
+      )
+    end
+
+    # `preferred_username` on Cognito
+    def preferred_username
+      @preferred_username ||= extract_attr('preferred_username')
+    end
+
+    # `sub` on Cognito
+    def sub
+      @sub ||= extract_attr('sub')
     end
   end
 end

--- a/app/services/cognito/update_preferred_username.rb
+++ b/app/services/cognito/update_preferred_username.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Class responsible for requesting a Cognito service to update `preferred_username` attribute
+  #
+  class UpdatePreferredUsername < CognitoBaseService
+    ##
+    # Initializer method for the service.
+    #
+    # ==== Attributes
+    # * +username+ - string, user email address
+    # * +preferred_username+ - UUID, eg '685f6373-75bc-4cb9-9a01-dbe1f9c383cf'
+    # * +sub+ - UUID, eg '98faf123-d201-48cb-8fd5-4b30c1f80918'
+    def initialize(username:, preferred_username:, sub:)
+      @username = username
+      @preferred_username = preferred_username
+      @sub = sub
+    end
+
+    ##
+    # Perform the call to AWS Cognito and returns true if errors were not raised
+    def call
+      return if preferred_username
+
+      admin_update_user
+    end
+
+    private
+
+    # Variables used internally by the service
+    attr_reader :username, :preferred_username, :sub
+
+    # Perform the call to Cognito service to update `preferred_username` attribute
+    def admin_update_user
+      log_action('Updating the preferred_username attribute')
+      client.admin_update_user_attributes(
+        { user_pool_id: user_pool_id, username: username, user_attributes: user_attributes }
+      )
+    rescue AWS_ERROR::ServiceError => e
+      log_error e
+      raise CallException, 'Something went wrong'
+    end
+
+    # An array of name-value pairs representing user attributes we want to update
+    def user_attributes
+      [
+        {
+          name: 'preferred_username',
+          value: sub
+        }
+      ]
+    end
+  end
+end

--- a/app/services/csv_upload_service.rb
+++ b/app/services/csv_upload_service.rb
@@ -103,7 +103,7 @@ class CsvUploadService < BaseService
 
   # Returns a hash.
   def file_metadata
-    { 'uploader-id': user.sub, 'csv-content-type': 'RETROFIT_LIST' }
+    { 'uploader-id': user.preferred_username, 'csv-content-type': 'RETROFIT_LIST' }
   end
 
   # AWS S3 Bucket Name.

--- a/spec/services/cognito/get_user_spec.rb
+++ b/spec/services/cognito/get_user_spec.rb
@@ -9,17 +9,20 @@ describe Cognito::GetUser do
   let(:cognito_response) do
     OpenStruct.new(username: username, user_attributes: [
                      OpenStruct.new(name: 'email', value: email),
+                     OpenStruct.new(name: 'preferred_username', value: preferred_username),
                      OpenStruct.new(name: 'sub', value: sub)
                    ])
   end
   let(:email) { 'test@example.com' }
   let(:username) { 'wojtek' }
+  let(:preferred_username) { SecureRandom.uuid }
   let(:sub) { SecureRandom.uuid }
 
   before do
     allow(Cognito::Client.instance).to receive(:get_user)
       .with(access_token: token)
       .and_return(cognito_response)
+    allow(Cognito::UpdatePreferredUsername).to receive(:call).and_return(true)
   end
 
   it 'returns an instance of the user class' do
@@ -44,6 +47,27 @@ describe Cognito::GetUser do
 
   it 'sets sub' do
     expect(service_call.sub).to eq(sub)
+  end
+
+  it 'calls Cognito::UpdatePreferredUsername service' do
+    service_call
+    expect(Cognito::UpdatePreferredUsername).to have_received(:call)
+  end
+
+  describe '.preferred_username' do
+    context 'when preferred_username not nil' do
+      it 'returns a proper value' do
+        expect(service_call.preferred_username).to eq(preferred_username)
+      end
+    end
+
+    context 'when preferred_username is nil' do
+      let(:preferred_username) { nil }
+
+      it 'returns a proper value' do
+        expect(service_call.preferred_username).to eq(sub)
+      end
+    end
   end
 
   context 'when the initial user is given' do

--- a/spec/services/cognito/update_preferred_username_spec.rb
+++ b/spec/services/cognito/update_preferred_username_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Cognito::UpdatePreferredUsername do
+  subject { described_class.call(username: username, preferred_username: preferred_username, sub: sub) }
+
+  let(:username) { 'user@example.com' }
+  let(:preferred_username) { SecureRandom.uuid }
+  let(:sub) { SecureRandom.uuid }
+  let(:user_attributes) { [{ name: 'preferred_username', value: sub }] }
+
+  before do
+    allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
+      user_pool_id: anything,
+      username: username,
+      user_attributes: user_attributes
+    ).and_return(true)
+  end
+
+  context 'when preferred_username is nil' do
+    let(:preferred_username) { nil }
+
+    context 'with successful call' do
+      it 'calls Cognito with proper params and returns true' do
+        expect(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
+          user_pool_id: anything,
+          username: username,
+          user_attributes: user_attributes
+        ).and_return(true)
+        subject
+      end
+    end
+
+    context 'when `Cognito::Client.instance.admin_update_user_attributes`
+           call fails with proper params' do
+      context 'and service raises `ServiceError`' do
+        before do
+          allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
+            user_pool_id: anything,
+            username: username,
+            user_attributes: user_attributes
+          ).and_raise(
+            Aws::CognitoIdentityProvider::Errors::ServiceError.new('', 'error')
+          )
+        end
+
+        it 'raises the `CallException`' do
+          expect { subject }.to raise_exception(Cognito::CallException)
+        end
+      end
+
+      context 'and service raises `UserNotFoundException`' do
+        before do
+          allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
+            user_pool_id: anything,
+            username: username,
+            user_attributes: user_attributes
+          ).and_raise(
+            Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', '')
+          )
+        end
+
+        it 'raises the `CallException`' do
+          expect { subject }.to raise_exception(Cognito::CallException)
+        end
+      end
+    end
+
+    context 'when preferred_username is not nil' do
+      it 'does not call Cognito' do
+        expect(Cognito::Client.instance).not_to receive(:call)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3419

## Description
<!--- Describe your changes in detail -->
* Added `preferred_username` attribute to `User` model
* Populate `preferred_username` with `sub` value on successful login and use it as metadata during file upload
* Added proper specs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
